### PR TITLE
Add Google reviews to dbt: source, staging, intermediate, mart

### DIFF
--- a/models/intermediate/int_google_reviews_daily.sql
+++ b/models/intermediate/int_google_reviews_daily.sql
@@ -1,0 +1,15 @@
+with reviews as (
+
+    select
+        snapshot_date                                          as date_day,
+        rating                                                 as google_rating,
+        user_ratings_total                                     as google_reviews_total,
+        user_ratings_total - lag(user_ratings_total) over (
+            order by snapshot_date
+        )                                                      as new_google_reviews
+    from {{ ref('stg_google__reviews') }}
+
+)
+
+select * from reviews
+where date_day >= '2026-03-01'

--- a/models/marts/mrt_biz_daily.sql
+++ b/models/marts/mrt_biz_daily.sql
@@ -39,6 +39,12 @@ instagram as (
 
 ),
 
+google_reviews as (
+
+    select * from {{ ref('int_google_reviews_daily') }}
+
+),
+
 final as (
 
     select
@@ -72,12 +78,18 @@ final as (
         -- instagram
         ig.instagram_followers,
         ig.instagram_media_count,
-        ig.new_instagram_followers
+        ig.new_instagram_followers,
+
+        -- google reviews
+        gr.google_reviews_total,
+        gr.new_google_reviews,
+        gr.google_rating
 
     from calendar cal
-    left join customers c   on c.date_day = cal.date_day
-    left join finance f     on f.date_day = cal.date_day
-    left join instagram ig  on ig.date_day = cal.date_day
+    left join customers c       on c.date_day = cal.date_day
+    left join finance f         on f.date_day = cal.date_day
+    left join instagram ig      on ig.date_day = cal.date_day
+    left join google_reviews gr on gr.date_day = cal.date_day
 
 )
 

--- a/models/staging/google/_schema.yml
+++ b/models/staging/google/_schema.yml
@@ -1,0 +1,15 @@
+version: 2
+
+models:
+  - name: stg_google__reviews
+    description: >
+      One row per day with the studio's Google Business Profile rating and total
+      review count (deduplicated to the latest snapshot per day).
+    columns:
+      - name: snapshot_date
+        tests:
+          - unique
+          - not_null
+      - name: user_ratings_total
+        tests:
+          - not_null

--- a/models/staging/google/_sources.yml
+++ b/models/staging/google/_sources.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+  - name: google
+    database: mazuria
+    schema: mazuria_raw
+
+    tables:
+      - name: google_reviews_snapshot

--- a/models/staging/google/stg_google__reviews.sql
+++ b/models/staging/google/stg_google__reviews.sql
@@ -1,0 +1,38 @@
+with source as (
+
+    select * from {{ source('google', 'google_reviews_snapshot') }}
+
+),
+
+deduplicated as (
+
+    select
+        place_id,
+        name,
+        rating,
+        user_ratings_total,
+        snapshot_date::date      as snapshot_date,
+        loaded_at,
+        row_number() over (
+            partition by snapshot_date
+            order by loaded_at desc
+        ) as rn
+    from source
+
+),
+
+final as (
+
+    select
+        place_id,
+        name,
+        rating,
+        user_ratings_total,
+        snapshot_date,
+        loaded_at
+    from deduplicated
+    where rn = 1
+
+)
+
+select * from final


### PR DESCRIPTION
New models stg_google__reviews and int_google_reviews_daily expose daily google_reviews_total, new_google_reviews, and google_rating from the mazuria_raw.google_reviews_snapshot table loaded by mazuria_greviews_etl. Wired into mrt_biz_daily alongside the Instagram metrics.

Builds on the biz-mart mart (customer sub-columns).