### PR TITLE
Add dbt-core runtime: dev/prod profile + build scripts

### DIFF
--- a/profile/profiles.yml
+++ b/profile/profiles.yml
@@ -1,0 +1,34 @@
+# dbt profile for the Mazuria PostgreSQL project (dbt-core).
+# Same credentials for both targets — only the schema differs, driven by the
+# generate_schema_name macro which keys off target.name:
+#   prod -> dbt_prod_<stg|int|mrt>   (what the Telegram report reads)
+#   dev  -> falls through to target.schema (dbt_dev_oleksandr), a single
+#           sandbox schema, so local builds never touch the prod marts.
+#
+# Credentials come from env vars in ../.env (PG_HOST, PG_USER, ...), loaded by
+# run_dbt.sh / setup_local_dbt.sh / run_dbt_mcp.sh — nothing secret lives here.
+#
+# Default target is dev for safety; run_dbt.sh builds with --target prod.
+
+mazuria_dbt:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('PG_HOST') }}"
+      port: "{{ env_var('PG_PORT') | int }}"
+      user: "{{ env_var('PG_USER') }}"
+      password: "{{ env_var('PG_PASSWORD') }}"
+      dbname: "{{ env_var('PG_DATABASE') }}"
+      schema: dbt_dev_oleksandr
+      threads: 4
+
+    prod:
+      type: postgres
+      host: "{{ env_var('PG_HOST') }}"
+      port: "{{ env_var('PG_PORT') | int }}"
+      user: "{{ env_var('PG_USER') }}"
+      password: "{{ env_var('PG_PASSWORD') }}"
+      dbname: "{{ env_var('PG_DATABASE') }}"
+      schema: public
+      threads: 4

--- a/run_dbt.sh
+++ b/run_dbt.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Canonical dbt-core build for the Mazuria project. Used by Airflow (the
+# mazuria_etl DAG SSHes to the Airflow VM and runs this) and runnable by hand.
+#
+# - Relocatable (works from whatever directory it lives in).
+# - Bootstraps the venv + dbt on first run via setup_local_dbt.sh.
+# - Loads DB creds from .env and uses the committed profile (profile/).
+# - Builds with --target prod by default (-> dbt_prod_* schemas); override with
+#   DBT_TARGET=dev for a sandbox build into dbt_dev_oleksandr.
+
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# On the VM the checkout always tracks main; pull latest. On a feature branch
+# (local dev) skip the pull so we don't merge main into the branch.
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+if [ "$branch" = "main" ]; then
+    git pull --ff-only origin main
+fi
+
+# Bootstrap the environment on first run (creates env/, installs dbt, deps).
+if [ ! -x "env/bin/dbt" ]; then
+    echo "venv missing — bootstrapping via setup_local_dbt.sh..."
+    ./setup_local_dbt.sh
+fi
+
+source env/bin/activate
+
+# Load DB credentials and point dbt at the committed profile.
+set -a
+source "$HERE/.env" 2>/dev/null || true
+set +a
+export DBT_PROFILES_DIR="$HERE/profile"
+
+dbt deps
+dbt build --target "${DBT_TARGET:-prod}"

--- a/run_dbt_mcp.sh
+++ b/run_dbt_mcp.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Launcher for the local dbt MCP server (invoked by ../.mcp.json).
+# Loads credentials from .env so no secrets live in .mcp.json, points the
+# server at the local Postgres profile, and disables the platform-only tools
+# (semantic layer / discovery / remote) since this is a dbt-core setup.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# Install the dbt MCP server into the project venv on first use (kept out of
+# setup_local_dbt.sh so the Airflow VM build stays lean).
+if [ ! -x "$HERE/env/bin/dbt-mcp" ]; then
+    "$HERE/env/bin/pip" install dbt-mcp >/dev/null
+fi
+
+# Load env vars from .env (PG_HOST, PG_USER, PG_PASSWORD, ...).
+set -a
+source "$HERE/.env" 2>/dev/null || true
+set +a
+
+# Local-only dbt MCP configuration.
+export DBT_PROJECT_DIR="$HERE"
+export DBT_PROFILES_DIR="$HERE/profile"
+export DBT_PATH="$HERE/env/bin/dbt"
+export DISABLE_SEMANTIC_LAYER="true"
+export DISABLE_DISCOVERY="true"
+export DISABLE_REMOTE="true"
+export DISABLE_SQL="true"
+export DISABLE_ADMIN_API="true"
+
+exec "$HERE/env/bin/dbt-mcp"

--- a/setup_local_dbt.sh
+++ b/setup_local_dbt.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# One-time local setup for the Mazuria dbt project + dbt MCP server.
+# Creates a venv, installs dbt-postgres + dbt-mcp, loads env vars from .env,
+# then runs `dbt debug` / `dbt deps` to verify the connection.
+#
+# Re-runnable: safe to run again to refresh deps.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+# Determine which Python command to use
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+else
+    echo "Error: Neither python3 nor python found. Please install Python."
+    exit 1
+fi
+
+echo "###############################"
+echo ""
+echo "Creating virtual environment with $PYTHON_CMD..."
+$PYTHON_CMD -m venv env
+source env/bin/activate
+echo ""
+
+echo "###############################"
+echo ""
+echo "Installing dbt-core, dbt-postgres..."
+python -m pip install --upgrade pip >/dev/null 2>&1
+python -m pip install dbt-core==1.9.8 dbt-postgres==1.9.0
+echo ""
+
+echo "###############################"
+echo ""
+echo "Loading environment from .env..."
+# Local profile dir (overrides the VM path baked into .env).
+set -a
+source .env 2>/dev/null || true
+set +a
+export DBT_PROFILES_DIR="$HERE/profile"
+echo "DBT_PROFILES_DIR=$DBT_PROFILES_DIR"
+echo ""
+
+echo "###############################"
+echo ""
+echo "Verifying connection and installing packages..."
+dbt debug
+dbt clean
+dbt deps
+echo ""
+echo "✓ Local dbt setup complete. dbt MCP launcher: ./run_dbt_mcp.sh"


### PR DESCRIPTION
Make dbt-core the canonical way to build the project (instead of dbt Cloud):
- profile/profiles.yml: committed mazuria_dbt profile with dev and prod targets sharing the same Postgres creds (from .env); schema differs by target name via generate_schema_name (prod -> dbt_prod_*, dev -> dbt_dev_oleksandr).
- setup_local_dbt.sh: relocatable venv + dbt-core/dbt-postgres bootstrap.
- run_dbt.sh: canonical build — pulls main (on main only), bootstraps the venv if missing, loads .env, runs `dbt build --target prod` (override via DBT_TARGET).
- run_dbt_mcp.sh: local dbt MCP launcher (self-installs dbt-mcp on first use).

.env and env/ stay gitignored.