### PR TITLE
Base new-customer date on first attendance only

### DIFF
--- a/models/intermediate/int_customers_by_course_daily.sql
+++ b/models/intermediate/int_customers_by_course_daily.sql
@@ -21,7 +21,7 @@ groups as (
         g.student_id,
         g.purchase_seq,
         g.course_id,
-        coalesce(g.first_attendance_date, g.started_at, g.created_at::date) as purchase_date,
+        g.first_attendance_date as purchase_date,
         g.ended_at
     from {{ ref('stg_notion__groups') }} g
 

--- a/models/intermediate/int_customers_daily.sql
+++ b/models/intermediate/int_customers_daily.sql
@@ -6,7 +6,7 @@ with groups as (
         g.purchase_seq,
         g.is_active,
         g.dict_group_id,
-        coalesce(g.first_attendance_date, g.started_at, g.created_at::date) as purchase_date,
+        g.first_attendance_date as purchase_date,
         g.ended_at,
         case
             when c.course_name ilike 'абонемент%' then 'subscription'

--- a/models/staging/notion/stg_notion__groups.sql
+++ b/models/staging/notion/stg_notion__groups.sql
@@ -28,7 +28,7 @@ final as (
         discount_percent,
         row_number() over (
             partition by student_id
-            order by coalesce(first_attendance_date, started_at::date, created_time::date)
+            order by first_attendance_date nulls last, created_time
         )                           as purchase_seq,
         -- dates
         first_attendance_date,


### PR DESCRIPTION
## What
Base a client's **purchase date on first attendance only** and align the new/repeat sequence to match.

- `int_customers_daily` / `int_customers_by_course_daily`: `purchase_date = first_attendance_date` (= `min(attendance.day)`, i.e. Notion's `перший_візит` rollup). Dropped the `started_at` (no longer populated) and `created_at` fallbacks.
- `stg_notion__groups`: `purchase_seq` now orders by `first_attendance_date NULLS LAST, created_time`, so `seq = 1` is the earliest **attended** enrollment — consistent with `purchase_date`.

## Why
`created_at` is a record-creation timestamp, not a real start signal. An incomplete June enrollment (no course, no `started_at`, no attendance — student phone `0969436536`) was dated by `created_at` to June, so it counted in `new_customers_groups` (=3) but had no course row in the per-course breakdown (sum =2). Basing the date on first attendance drops such phantom rows, so enrollments only count once the student actually shows up, and the headline reconciles with the per-course rows.

## Effect
- Enrollments with no attendance no longer count as new/active clients.
- Slightly shifts historical new/repeat splits (toward first-visit semantics) — intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)