### PR TITLE
Exclude course-less enrollments in stg_notion__groups

### DIFF
--- a/models/staging/notion/stg_notion__groups.sql
+++ b/models/staging/notion/stg_notion__groups.sql
@@ -3,6 +3,10 @@ with base as (
     select * from {{ ref('base_notion__groups') }}
     where not coalesce(archived, false)
         and not coalesce(in_trash, false)
+        -- enrollments must have a course; course-less rows are incomplete
+        -- records that would otherwise inflate new/active counts and break
+        -- reconciliation with the per-course breakdown.
+        and course_id is not null
 
 ),
 


### PR DESCRIPTION
Filter out Group records with no course (course_id is null) at the staging layer. These are incomplete enrollments that inflate new/active counts and can't appear in the per-course breakdown, breaking reconciliation. Only the two customer models consume this staging model, so the change is contained.